### PR TITLE
Add Instagram link to Sign In screen

### DIFF
--- a/app/src/main/java/com/example/bytewisdom/ui/screens/SignInScreen.kt
+++ b/app/src/main/java/com/example/bytewisdom/ui/screens/SignInScreen.kt
@@ -1,9 +1,18 @@
 package com.example.bytewisdom.ui.screens
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 
@@ -15,62 +24,91 @@ fun SignInScreen(
 ) {
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    val context = LocalContext.current
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.Center
+            .padding(24.dp)
     ) {
-        Text(
-            text = "Sign In",
-            style = MaterialTheme.typography.headlineMedium
-        )
-
-        Spacer(Modifier.height(24.dp))
-
-        OutlinedTextField(
-            value = username,
-            onValueChange = { username = it },
-            label = { Text("Username") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(Modifier.height(12.dp))
-
-        OutlinedTextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Password") },
-            singleLine = true,
-            visualTransformation = PasswordVisualTransformation(),
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(Modifier.height(24.dp))
-
-        Button(
-            onClick = { onSignIn(username, password) },
-            modifier = Modifier.fillMaxWidth()
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.Center
         ) {
-            Text("Sign In")
-        }
-
-        TextButton(
-            onClick = onNavigateRegister,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Create an account")
-        }
-
-        errorText?.let {
-            Spacer(Modifier.height(12.dp))
             Text(
-                text = it,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodyMedium
+                text = "Sign In",
+                style = MaterialTheme.typography.headlineMedium,
             )
+
+            Spacer(Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = username,
+                onValueChange = { username = it },
+                label = { Text("Username") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = { onSignIn(username, password) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Sign In")
+            }
+
+            TextButton(
+                onClick = onNavigateRegister,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Create an account")
+            }
+
+            errorText?.let {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
         }
+
+        Icon(
+            painter = painterResource(R.drawable.ic_instagram),
+            contentDescription = "Instagram",
+            tint = Color.Unspecified,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .size(32.dp)
+                .clickable { openInstagram(context) }
+        )
+    }
+}
+
+private fun openInstagram(context: Context) {
+    val uri = Uri.parse("https://www.instagram.com/bytewisdom_motivation/")
+    val instagramIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+        setPackage("com.instagram.android")
+    }
+    try {
+        context.startActivity(instagramIntent)
+    } catch (e: ActivityNotFoundException) {
+        context.startActivity(Intent(Intent.ACTION_VIEW, uri))
     }
 }

--- a/app/src/main/res/drawable/ic_instagram.xml
+++ b/app/src/main/res/drawable/ic_instagram.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M7.75,2h8.5A5.75,5.75,0,0,1,22,7.75v8.5A5.75,5.75,0,0,1,16.25,22H7.75A5.75,5.75,0,0,1,2,16.25V7.75A5.75,5.75,0,0,1,7.75,2Z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,7a5,5,0,1,0,5,5A5,5,0,0,0,12,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,12,15Z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M17.5,6.5a1.5,1.5,0,1,1-3,0,1.5,1.5,0,0,1,3,0Z" />
+</vector>


### PR DESCRIPTION
## Summary
- Add clickable Instagram icon to Sign In screen linking to ByteWisdom Instagram page
- Include vector drawable for Instagram logo

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b72da999d083239807b3e0599e7f94